### PR TITLE
Do not assume that jQuery UI is loaded at all.

### DIFF
--- a/chrome-tabs.js
+++ b/chrome-tabs.js
@@ -3,7 +3,7 @@ var fs = require('fs'),
 
 var $ = jQuery;
 
-if (!$.ui.sortable) {
+if (!$.ui || !$.ui.sortable) {
   require('./jquery-ui-1.10.3.custom.js');
 }
 


### PR DESCRIPTION
Without this change `chromeTabs` will fail to initialize when jQuery is present, but jQuery UI is not.
